### PR TITLE
nix: clean up and refactor

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,34 +1,21 @@
-{ sources ? (import ./nix/sources.nix)
-, compiler ? "ghc882"
+let
+  sources = import ./nix/sources.nix;
+in
+{ pkgs ? import sources.unstable { }
 }:
 let
-  overlay = self: super: {
-    haskell = super.haskell // {
-      packages = super.haskell.packages // {
-        "${compiler}" = super.haskell.packages.${compiler}.override {
-          overrides = hself: hsuper: with self.haskell.lib; {};
-        };
-      };
-    };
+  hspkgs = pkgs.haskellPackages.override {
+    overrides = hself: hsuper: with pkgs.haskell.lib; { };
   };
 
-  pkgs = (
-    import sources.unstable {
-      overlays = [
-        overlay
-      ];
-    }
-  );
-
-  inherit (pkgs.haskellPackages)
+  inherit (hspkgs)
     callCabal2nix
-    shellFor
     ;
+
   inherit (pkgs)
-    lib
     nix-gitignore
     ;
 
-  shell-cmd = callCabal2nix "shell-cmd" (nix-gitignore.gitignoreSource [] ./.) {};
+  shell-cmd = callCabal2nix "shell-cmd" (nix-gitignore.gitignoreSource [ ] ./.) { };
 in
-  shell-cmd
+shell-cmd

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "029a5de08390bb03c3f44230b064fd1850c6658a",
-        "sha256": "03fjkzhrs2avcvdabgm7a65rnyjaqbqdnv4q86qyjkkwg64g5m8x",
+        "rev": "8e2b14aceb1d40c7e8b84c03a7c78955359872bb",
+        "sha256": "0zzjpd9smr7rxzrdf6raw9kbj42fbvafxb5bz36lcxgv290pgsm8",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/029a5de08390bb03c3f44230b064fd1850c6658a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/8e2b14aceb1d40c7e8b84c03a7c78955359872bb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,14 @@
 let
-  shell-cmd = (import ./default.nix {});
   sources = import ./nix/sources.nix;
-  pkgs = (import sources.unstable {});
-in pkgs.haskellPackages.shellFor {
+in
+{ pkgs ? import sources.unstable { }
+}:
+let
+  shell-cmd = import ./default.nix {
+    inherit pkgs;
+  };
+in
+pkgs.haskellPackages.shellFor {
   packages = _: [
     shell-cmd
   ];


### PR DESCRIPTION
- make it possible to override the input `pkgs`
- just use the default compiler, always